### PR TITLE
Add pong prompts

### DIFF
--- a/.context/roadmap.md
+++ b/.context/roadmap.md
@@ -2,9 +2,9 @@
 
 This roadmap breaks the project into logical phases. Each phase builds upon the previous one and introduces new domains. Before starting a phase, the agent should read the relevant domain rules and update `active_task.md` accordingly.
 
-## Phase 1 – Core Loop (Single‑Player Foundation)
+## Phase 1 – Core Loop (Single-Player Foundation)
 
-**Goal:** Build a local, single‑player Pong game without networking.
+**Goal:** Build a local, single-player Pong game without networking.
 
 **Context Files:** `domain_ui.md` (visuals, input), `domain_audio.md` (optional early sound).
 
@@ -14,20 +14,20 @@ This roadmap breaks the project into logical phases. Each phase builds upon the 
 3. **Implement core entities.** Use Phaser’s Arcade Physics to create `Paddle` and `Ball` classes. Apply the synthwave colours and bloom effects defined in `domain_ui.md`.
 4. **Add input handling.** For mobile, divide the screen into invisible touch zones; for desktop, map arrow keys.
 5. **Implement scoring logic.** Display scores using the `Press Start 2P` font. Reset the ball after a point is scored.
-6. **Ensure responsiveness.** Use `Phaser.Scale.FIT` and relative positioning to scale to different aspect ratios【610672879337516†L146-L151】.
-7. **Validate.** Run the game locally and ensure the ball bounces off paddles and walls correctly, paddles move smoothly, and the game scales on mobile screens【795071169652698†L418-L428】.
+6. **Ensure responsiveness.** Use `Phaser.Scale.FIT` and relative positioning to scale to different aspect ratios.
+7. **Validate.** Run the game locally and ensure the ball bounces off paddles and walls correctly, paddles move smoothly, and the game scales on mobile screens.
 
 ## Phase 2 – Networking Plumbing
 
-**Goal:** Establish real‑time communication between two clients and a server.
+**Goal:** Establish real-time communication between two clients and a server.
 
 **Context Files:** `domain_net.md` (networking), `domain_ui.md` (input remains relevant).
 
 **Tasks:**
 1. **Create the server.** Implement a Node.js (TypeScript) server with Socket.io. Start with a basic HTTP and WebSocket server.
-2. **Define game state schema.** Add TypeScript interfaces (`Player`, `GameState`) in the `/shared` folder so both client and server agree on the structure【795071169652698†L441-L448】.
+2. **Define game state schema.** Add TypeScript interfaces (`Player`, `GameState`) in the `/shared` folder so both client and server agree on the structure.
 3. **Implement room logic.** Use Socket.io rooms to match two players. Emit events when players join or leave.
-4. **Echo test.** Have the client send a message to the server and log it back to ensure the connection works【795071169652698†L430-L439】.
+4. **Echo test.** Have the client send a message to the server and log it back to ensure the connection works.
 5. **Sync initial positions.** Send the initial paddle and ball positions from the server to the clients on join.
 6. **Validate.** Open two browser windows locally; both should connect to the same room and see each other’s presence.
 
@@ -38,12 +38,12 @@ This roadmap breaks the project into logical phases. Each phase builds upon the 
 **Context Files:** `domain_net.md` (authoritative server & client prediction), `domain_ui.md` (rendering).
 
 **Tasks:**
-1. **Server simulation loop.** Run a fixed‑rate loop on the server (e.g. 60 Hz) that updates the game state: apply velocities, handle collisions, update scores, and broadcast state deltas【610672879337516†L359-L393】.
+1. **Server simulation loop.** Run a fixed-rate loop on the server (e.g. 60 Hz) that updates the game state: apply velocities, handle collisions, update scores, and broadcast state deltas.
 2. **Input messages.** Clients send input intents (`UP`, `DOWN`, `STOP`) instead of absolute positions.
-3. **Client prediction.** On receiving local input, immediately move the paddle; when authoritative updates arrive, reconcile differences as described in `domain_net.md`【610672879337516†L389-L392】.
-4. **Interpolation.** Buffer remote updates and interpolate positions to smooth out motion【610672879337516†L389-L392】.
-5. **Power‑ups (optional).** Introduce power‑up logic on the server: spawning, collision handling, and timed effects【610672879337516†L420-L443】.
-6. **Validate under latency.** Use Chrome DevTools to simulate network lag and ensure the game remains playable【795071169652698†L449-L451】.
+3. **Client prediction.** On receiving local input, immediately move the paddle; when authoritative updates arrive, reconcile differences as described in `domain_net.md`.
+4. **Interpolation.** Buffer remote updates and interpolate positions to smooth out motion.
+5. **Power-ups (optional).** Introduce power-up logic on the server: spawning, collision handling, and timed effects.
+6. **Validate under latency.** Use Chrome DevTools to simulate network lag and ensure the game remains playable.
 
 ## Phase 4 – Polish, Audio & Deployment
 
@@ -52,11 +52,11 @@ This roadmap breaks the project into logical phases. Each phase builds upon the 
 **Context Files:** `domain_audio.md`, `domain_leaderboard.md`, `domain_qa.md`.
 
 **Tasks:**
-1. **Audio integration.** Implement the audio sprite and mobile audio unlock pattern【610672879337516†L396-L416】.
-2. **Visual effects.** Add screen shake on scoring, particle explosions for power‑ups, and CRT shaders【610672879337516†L419-L443】.
-3. **Leaderboard integration.** Hook up Firestore: record scores server‑side at the end of a match, retrieve the top 10, and display them in a dedicated scene or modal【610672879337516†L388-L390】.
-4. **Testing & CI.** Expand test coverage, particularly integration and E2E tests; configure headless Phaser testing and ensure CI passes【795071169652698†L469-L503】.
-5. **Deployment.** Dockerize the server and configure the deployment pipeline to a PaaS (e.g. Railway). Use GitHub Pages or similar to host the client and ensure WebSocket endpoints are reachable【795071169652698†L507-L516】.
+1. **Audio integration.** Implement the audio sprite and mobile audio unlock pattern.
+2. **Visual effects.** Add screen shake on scoring, particle explosions for power-ups, and CRT shaders.
+3. **Leaderboard integration.** Hook up Firestore: record scores server-side at the end of a match, retrieve the top 10, and display them in a dedicated scene or modal.
+4. **Testing & CI.** Expand test coverage, particularly integration and E2E tests; configure headless Phaser testing and ensure CI passes.
+5. **Deployment.** Dockerize the server and configure the deployment pipeline to a PaaS (e.g. Railway). Use GitHub Pages or similar to host the client and ensure WebSocket endpoints are reachable.
 6. **Documentation.** Update `AI_REPO_GUIDE.md` and architecture diagrams to reflect the final system. Ensure `.context/state/active_task.md` marks the project as complete.
 
 By following this phased roadmap, the AI agent can build the project incrementally, validate each stage, and produce a polished final game. Each phase corresponds to a discrete milestone, enabling clear progress tracking and targeted rule loading.

--- a/.context/roadmap.md
+++ b/.context/roadmap.md
@@ -1,0 +1,62 @@
+# Development Roadmap
+
+This roadmap breaks the project into logical phases. Each phase builds upon the previous one and introduces new domains. Before starting a phase, the agent should read the relevant domain rules and update `active_task.md` accordingly.
+
+## Phase 1 – Core Loop (Single‑Player Foundation)
+
+**Goal:** Build a local, single‑player Pong game without networking.
+
+**Context Files:** `domain_ui.md` (visuals, input), `domain_audio.md` (optional early sound).
+
+**Tasks:**
+1. **Set up the development environment.** Initialize a Vite or Webpack project with TypeScript support. Install Phaser 3 via npm or CDN.
+2. **Create the main scene.** Implement `BootScene` to preload assets (fonts, shaders, audio sprite) and `GameScene` to contain the game loop.
+3. **Implement core entities.** Use Phaser’s Arcade Physics to create `Paddle` and `Ball` classes. Apply the synthwave colours and bloom effects defined in `domain_ui.md`.
+4. **Add input handling.** For mobile, divide the screen into invisible touch zones; for desktop, map arrow keys【610672879337516†L146-L154】.
+5. **Implement scoring logic.** Display scores using the `Press Start 2P` font. Reset the ball after a point is scored.
+6. **Ensure responsiveness.** Use `Phaser.Scale.FIT` and relative positioning to scale to different aspect ratios【610672879337516†L146-L151】.
+7. **Validate.** Run the game locally and ensure the ball bounces off paddles and walls correctly, paddles move smoothly, and the game scales on mobile screens【795071169652698†L418-L428】.
+
+## Phase 2 – Networking Plumbing
+
+**Goal:** Establish real‑time communication between two clients and a server.
+
+**Context Files:** `domain_net.md` (networking), `domain_ui.md` (input remains relevant).
+
+**Tasks:**
+1. **Create the server.** Implement a Node.js (TypeScript) server with Socket.io. Start with a basic HTTP and WebSocket server.
+2. **Define game state schema.** Add TypeScript interfaces (`Player`, `GameState`) in the `/shared` folder so both client and server agree on the structure【795071169652698†L441-L448】.
+3. **Implement room logic.** Use Socket.io rooms to match two players. Emit events when players join or leave.
+4. **Echo test.** Have the client send a message to the server and log it back to ensure the connection works【795071169652698†L430-L439】.
+5. **Sync initial positions.** Send the initial paddle and ball positions from the server to the clients on join.
+6. **Validate.** Open two browser windows locally; both should connect to the same room and see each other’s presence.
+
+## Phase 3 – Authoritative Physics Integration
+
+**Goal:** Migrate game logic to the server and implement prediction/interpolation.
+
+**Context Files:** `domain_net.md` (authoritative server & client prediction), `domain_ui.md` (rendering).
+
+**Tasks:**
+1. **Server simulation loop.** Run a fixed‑rate loop on the server (e.g. 60 Hz) that updates the game state: apply velocities, handle collisions, update scores, and broadcast state deltas【610672879337516†L359-L393】.
+2. **Input messages.** Clients send input intents (`UP`, `DOWN`, `STOP`) instead of absolute positions.
+3. **Client prediction.** On receiving local input, immediately move the paddle; when authoritative updates arrive, reconcile differences as described in `domain_net.md`【610672879337516†L389-L392】.
+4. **Interpolation.** Buffer remote updates and interpolate positions to smooth out motion【610672879337516†L389-L392】.
+5. **Power‑ups (optional).** Introduce power‑up logic on the server: spawning, collision handling, and timed effects【610672879337516†L420-L443】.
+6. **Validate under latency.** Use Chrome DevTools to simulate network lag and ensure the game remains playable【795071169652698†L449-L451】.
+
+## Phase 4 – Polish, Audio & Deployment
+
+**Goal:** Achieve production readiness, add audio and visual juice, integrate persistence, and deploy.
+
+**Context Files:** `domain_audio.md`, `domain_leaderboard.md`, `domain_qa.md`.
+
+**Tasks:**
+1. **Audio integration.** Implement the audio sprite and mobile audio unlock pattern【610672879337516†L396-L416】.
+2. **Visual effects.** Add screen shake on scoring, particle explosions for power‑ups, and CRT shaders【610672879337516†L419-L443】.
+3. **Leaderboard integration.** Hook up Firestore: record scores server‑side at the end of a match, retrieve the top 10, and display them in a dedicated scene or modal【610672879337516†L388-L390】.
+4. **Testing & CI.** Expand test coverage, particularly integration and E2E tests; configure headless Phaser testing and ensure CI passes【795071169652698†L469-L503】.
+5. **Deployment.** Dockerize the server and configure the deployment pipeline to a PaaS (e.g. Railway). Use GitHub Pages or similar to host the client and ensure WebSocket endpoints are reachable【795071169652698†L507-L516】.
+6. **Documentation.** Update `AI_REPO_GUIDE.md` and architecture diagrams to reflect the final system. Ensure `.context/state/active_task.md` marks the project as complete.
+
+By following this phased roadmap, the AI agent can build the project incrementally, validate each stage, and produce a polished final game. Each phase corresponds to a discrete milestone, enabling clear progress tracking and targeted rule loading.

--- a/.context/roadmap.md
+++ b/.context/roadmap.md
@@ -12,7 +12,7 @@ This roadmap breaks the project into logical phases. Each phase builds upon the 
 1. **Set up the development environment.** Initialize a Vite or Webpack project with TypeScript support. Install Phaser 3 via npm or CDN.
 2. **Create the main scene.** Implement `BootScene` to preload assets (fonts, shaders, audio sprite) and `GameScene` to contain the game loop.
 3. **Implement core entities.** Use Phaser’s Arcade Physics to create `Paddle` and `Ball` classes. Apply the synthwave colours and bloom effects defined in `domain_ui.md`.
-4. **Add input handling.** For mobile, divide the screen into invisible touch zones; for desktop, map arrow keys【610672879337516†L146-L154】.
+4. **Add input handling.** For mobile, divide the screen into invisible touch zones; for desktop, map arrow keys.
 5. **Implement scoring logic.** Display scores using the `Press Start 2P` font. Reset the ball after a point is scored.
 6. **Ensure responsiveness.** Use `Phaser.Scale.FIT` and relative positioning to scale to different aspect ratios【610672879337516†L146-L151】.
 7. **Validate.** Run the game locally and ensure the ball bounces off paddles and walls correctly, paddles move smoothly, and the game scales on mobile screens【795071169652698†L418-L428】.

--- a/.context/rules/domain_audio.md
+++ b/.context/rules/domain_audio.md
@@ -1,0 +1,21 @@
+# Domain Rules: Audio & Sound Effects
+
+## Audio Sprites
+
+- Combine all sound effects (paddle hit, score, power‑up, countdown, win/lose) into a single audio file and generate a JSON cue sheet with start/end offsets.
+- Load the audio sprite in Phaser using the `this.load.audioSprite` method.
+- When playing a sound, reference the cue name rather than loading individual `.mp3` files. This reduces HTTP requests and mobile latency.
+
+## Unlocking Audio on Mobile
+
+- Mobile browsers block audio playback until the user interacts with the page. To unlock audio, play a silent buffer from the audio sprite when the user first taps (e.g. when pressing “Start Game”).
+- Only after unlocking should actual sounds be played. If audio is attempted before unlocking, catch and ignore the exception.
+
+## Mixing & Levels
+
+- Keep sound effects subtle so they complement the retro aesthetic. Use short, 8‑bit inspired bleeps and whooshes.
+- Provide a global mute toggle in the UI. Respect the OS volume.
+
+## Music (optional)
+
+- If you implement background music, loop a synthwave track. Fade the music in on the title screen and out when the game ends. Do not overpower sound effects.

--- a/.context/rules/domain_audio.md
+++ b/.context/rules/domain_audio.md
@@ -2,7 +2,7 @@
 
 ## Audio Sprites
 
-- Combine all sound effects (paddle hit, score, power‑up, countdown, win/lose) into a single audio file and generate a JSON cue sheet with start/end offsets.
+- Combine all sound effects (paddle hit, score, power-up, countdown, win/lose) into a single audio file and generate a JSON cue sheet with start/end offsets.
 - Load the audio sprite in Phaser using the `this.load.audioSprite` method.
 - When playing a sound, reference the cue name rather than loading individual `.mp3` files. This reduces HTTP requests and mobile latency.
 
@@ -13,7 +13,7 @@
 
 ## Mixing & Levels
 
-- Keep sound effects subtle so they complement the retro aesthetic. Use short, 8‑bit inspired bleeps and whooshes.
+- Keep sound effects subtle so they complement the retro aesthetic. Use short, 8-bit inspired bleeps and whooshes.
 - Provide a global mute toggle in the UI. Respect the OS volume.
 
 ## Music (optional)

--- a/.context/rules/domain_leaderboard.md
+++ b/.context/rules/domain_leaderboard.md
@@ -4,8 +4,8 @@ These rules govern how scores are stored and retrieved. A persistent leaderboard
 
 ## Database Selection
 
-- **Use Firestore (Firebase v9)**: Choose the Firestore NoSQL document database instead of a SQL database. Firestore stores documents in collections, which suits the simple `{ name: string, score: number }` structure of a leaderboard and integrates easily with web clients. The v9 modular SDK must be used for tree‑shakeable imports (e.g. `import { getFirestore, collection, addDoc, getDocs, query, orderBy, limit } from 'firebase/firestore'`). The analysis in the technical specification highlights that Firestore is lightweight and avoids the overhead of real‑time replication mechanisms required by SQL databases.
-- **Avoid Supabase or heavy SQL**: A PostgreSQL solution with real‑time triggers (e.g. Supabase) is unnecessary for a simple high‑score table and adds complexity such as schema migrations and row‑level security【610672879337516†L359-L390】.
+- **Use Firestore (Firebase v9)**: Choose the Firestore NoSQL document database instead of a SQL database. Firestore stores documents in collections, which suits the simple `{ name: string, score: number }` structure of a leaderboard and integrates easily with web clients. The v9 modular SDK must be used for tree-shakeable imports (e.g. `import { getFirestore, collection, addDoc, getDocs, query, orderBy, limit } from 'firebase/firestore'`). The analysis in the technical specification highlights that Firestore is lightweight and avoids the overhead of real-time replication mechanisms required by SQL databases.
+- **Avoid Supabase or heavy SQL**: A PostgreSQL solution with real-time triggers (e.g. Supabase) is unnecessary for a simple high-score table and adds complexity such as schema migrations and row-level security.
 
 ## Schema and Collection
 
@@ -14,19 +14,19 @@ These rules govern how scores are stored and retrieved. A persistent leaderboard
 
 ## Writing Scores
 
-- After each match ends on the server, call an asynchronous function `recordScore(name: string, score: number)` that uses `addDoc(collection(db, 'scores'), { name, score, createdAt: serverTimestamp() })`. In prototypes we accept client‑submitted names and scores, but note that a production system should validate scores server‑side【610672879337516†L389-L396】.
+- After each match ends on the server, call an asynchronous function `recordScore(name: string, score: number)` that uses `addDoc(collection(db, 'scores'), { name, score, createdAt: serverTimestamp() })`. In prototypes we accept client-submitted names and scores, but note that a production system should validate scores server-side.
 - Never write scores from the client directly. Route all score submissions through the server so that the server can enforce fair play and attach the correct timestamp.
 - Handle errors gracefully: wrap Firestore calls in `try…catch` and log failures without crashing the game.
 
 ## Reading the Leaderboard
 
-- To display the leaderboard, fetch the top 10 scores ordered by `score` descending using a query: `query(collection(db, 'scores'), orderBy('score', 'desc'), limit(10))` and then await `getDocs`【610672879337516†L388-L390】.
-- Cache results client‑side for the session to avoid repeated reads. Refresh the leaderboard after a new score is recorded.
+- To display the leaderboard, fetch the top 10 scores ordered by `score` descending using a query: `query(collection(db, 'scores'), orderBy('score', 'desc'), limit(10))` and then await `getDocs`.
+- Cache results client-side for the session to avoid repeated reads. Refresh the leaderboard after a new score is recorded.
 - Display player names alongside their scores. Consider anonymizing or truncating names if they are too long (e.g. max 8 characters) to fit the UI.
 
 ## Security Considerations
 
-- For the scope of this project, client‑side submission is accepted to simplify the prototype. However, note in comments that a production deployment should include validation (e.g. check that a player’s score was legitimately achieved) and authentication (e.g. Firebase Auth)【610672879337516†L389-L396】.
+- For the scope of this project, client-side submission is accepted to simplify the prototype. However, note in comments that a production deployment should include validation (e.g. check that a player’s score was legitimately achieved) and authentication (e.g. Firebase Auth).
 - Configure Firestore security rules (not implemented in code) to allow read access for everyone but restrict write access to the server. This prevents anonymous clients from injecting fake scores.
 
 ## Integration with UI
@@ -34,4 +34,4 @@ These rules govern how scores are stored and retrieved. A persistent leaderboard
 - The client should provide a “Submit Score” screen after a match ends. The player enters their name via an input field; the client sends this name and the final score to the server via Socket.io.
 - In the lobby or main menu, include a “Leaderboard” scene or modal that displays the top scores. Use the synthwave typography and colours defined in `domain_ui.md`.
 
-By following these rules, the leaderboard remains simple, secure, and consistent with the technical specification’s guidance on using Firestore and limiting queries to a manageable size【610672879337516†L359-L390】.
+By following these rules, the leaderboard remains simple, secure, and consistent with the technical specification’s guidance on using Firestore and limiting queries to a manageable size.

--- a/.context/rules/domain_leaderboard.md
+++ b/.context/rules/domain_leaderboard.md
@@ -4,7 +4,7 @@ These rules govern how scores are stored and retrieved. A persistent leaderboard
 
 ## Database Selection
 
-- **Use Firestore (Firebase v9)**: Choose the Firestore NoSQL document database instead of a SQL database. Firestore stores documents in collections, which suits the simple `{ name: string, score: number }` structure of a leaderboard and integrates easily with web clients. The v9 modular SDK must be used for tree‑shakeable imports (e.g. `import { getFirestore, collection, addDoc, getDocs, query, orderBy, limit } from 'firebase/firestore'`). The analysis in the technical specification highlights that Firestore is lightweight and avoids the overhead of real‑time replication mechanisms required by SQL databases【610672879337516†L359-L389】.
+- **Use Firestore (Firebase v9)**: Choose the Firestore NoSQL document database instead of a SQL database. Firestore stores documents in collections, which suits the simple `{ name: string, score: number }` structure of a leaderboard and integrates easily with web clients. The v9 modular SDK must be used for tree‑shakeable imports (e.g. `import { getFirestore, collection, addDoc, getDocs, query, orderBy, limit } from 'firebase/firestore'`). The analysis in the technical specification highlights that Firestore is lightweight and avoids the overhead of real‑time replication mechanisms required by SQL databases.
 - **Avoid Supabase or heavy SQL**: A PostgreSQL solution with real‑time triggers (e.g. Supabase) is unnecessary for a simple high‑score table and adds complexity such as schema migrations and row‑level security【610672879337516†L359-L390】.
 
 ## Schema and Collection

--- a/.context/rules/domain_leaderboard.md
+++ b/.context/rules/domain_leaderboard.md
@@ -1,0 +1,37 @@
+# Domain Rules: Leaderboards & Persistence
+
+These rules govern how scores are stored and retrieved. A persistent leaderboard enhances replay value but must be implemented with efficiency and security in mind.
+
+## Database Selection
+
+- **Use Firestore (Firebase v9)**: Choose the Firestore NoSQL document database instead of a SQL database. Firestore stores documents in collections, which suits the simple `{ name: string, score: number }` structure of a leaderboard and integrates easily with web clients. The v9 modular SDK must be used for tree‑shakeable imports (e.g. `import { getFirestore, collection, addDoc, getDocs, query, orderBy, limit } from 'firebase/firestore'`). The analysis in the technical specification highlights that Firestore is lightweight and avoids the overhead of real‑time replication mechanisms required by SQL databases【610672879337516†L359-L389】.
+- **Avoid Supabase or heavy SQL**: A PostgreSQL solution with real‑time triggers (e.g. Supabase) is unnecessary for a simple high‑score table and adds complexity such as schema migrations and row‑level security【610672879337516†L359-L390】.
+
+## Schema and Collection
+
+- Create a Firestore collection called `scores` where each document contains a `name` (string), `score` (number), and optionally a `timestamp` (server timestamp) for sorting ties.
+- Use server timestamps (`serverTimestamp()`) instead of client clocks to avoid tampering. Import `serverTimestamp` from `firebase/firestore`.
+
+## Writing Scores
+
+- After each match ends on the server, call an asynchronous function `recordScore(name: string, score: number)` that uses `addDoc(collection(db, 'scores'), { name, score, createdAt: serverTimestamp() })`. In prototypes we accept client‑submitted names and scores, but note that a production system should validate scores server‑side【610672879337516†L389-L396】.
+- Never write scores from the client directly. Route all score submissions through the server so that the server can enforce fair play and attach the correct timestamp.
+- Handle errors gracefully: wrap Firestore calls in `try…catch` and log failures without crashing the game.
+
+## Reading the Leaderboard
+
+- To display the leaderboard, fetch the top 10 scores ordered by `score` descending using a query: `query(collection(db, 'scores'), orderBy('score', 'desc'), limit(10))` and then await `getDocs`【610672879337516†L388-L390】.
+- Cache results client‑side for the session to avoid repeated reads. Refresh the leaderboard after a new score is recorded.
+- Display player names alongside their scores. Consider anonymizing or truncating names if they are too long (e.g. max 8 characters) to fit the UI.
+
+## Security Considerations
+
+- For the scope of this project, client‑side submission is accepted to simplify the prototype. However, note in comments that a production deployment should include validation (e.g. check that a player’s score was legitimately achieved) and authentication (e.g. Firebase Auth)【610672879337516†L389-L396】.
+- Configure Firestore security rules (not implemented in code) to allow read access for everyone but restrict write access to the server. This prevents anonymous clients from injecting fake scores.
+
+## Integration with UI
+
+- The client should provide a “Submit Score” screen after a match ends. The player enters their name via an input field; the client sends this name and the final score to the server via Socket.io.
+- In the lobby or main menu, include a “Leaderboard” scene or modal that displays the top scores. Use the synthwave typography and colours defined in `domain_ui.md`.
+
+By following these rules, the leaderboard remains simple, secure, and consistent with the technical specification’s guidance on using Firestore and limiting queries to a manageable size【610672879337516†L359-L390】.

--- a/.context/rules/domain_leaderboard.md
+++ b/.context/rules/domain_leaderboard.md
@@ -9,7 +9,7 @@ These rules govern how scores are stored and retrieved. A persistent leaderboard
 
 ## Schema and Collection
 
-- Create a Firestore collection called `scores` where each document contains a `name` (string), `score` (number), and optionally a `timestamp` (server timestamp) for sorting ties.
+- Create a Firestore collection called `scores` where each document contains a `name` (string), `score` (number), and a `timestamp` (server timestamp) for sorting ties.
 - Use server timestamps (`serverTimestamp()`) instead of client clocks to avoid tampering. Import `serverTimestamp` from `firebase/firestore`.
 
 ## Writing Scores

--- a/.context/rules/domain_net.md
+++ b/.context/rules/domain_net.md
@@ -1,0 +1,35 @@
+# Domain Rules: Networking & Game State
+
+These rules govern the server architecture and client‑server interactions.
+
+## Architecture
+
+- **Pattern:** **Authoritative server** – the server is the single source of truth for game state; clients render and predict but never authoritatively change state.
+- **Protocol:** WebSockets using Socket.io v4. Use JSON for messages. Do not rely on HTTP polling.
+
+## Server Logic
+
+- Implement the server in Node.js using TypeScript.
+- Maintain an in‑memory game state object for each match. Define `Player` and `GameState` TypeScript classes or interfaces in `/shared` so client and server agree on the shape.
+- Run a fixed‑tick simulation loop at 60 FPS using `setInterval()` or a game loop library. Each tick should:
+  1. Apply velocity to paddles and the ball based on current inputs.
+  2. Detect and handle collisions.
+  3. Update scores and power‑up timers.
+  4. Broadcast the minimal state delta to clients via Socket.io `emit`.
+- Clients must send **intent messages** (`{input: 'UP' | 'DOWN' | 'STOP'}`) rather than positions. Do not send full coordinates.
+
+## Client Logic
+
+- On input, immediately move the local paddle for responsiveness (client‑side prediction) and send the intent to the server.
+- When receiving state updates, reconcile the predicted position with the authoritative value. If the difference exceeds 5 pixels, snap to the server position; otherwise continue.
+- For remote entities (opponent paddle and ball), buffer updates and interpolate between the last two states using `Phaser.Math.Linear` to smooth motion.
+
+## Rooms & Matchmaking
+
+- Use Socket.io rooms to isolate matches. A player joins or creates a room; if the room has one player, it waits; if two, the game starts. Additional players are rejected or queued.
+- On disconnection, end the match, declare the remaining player the winner, and persist the score.
+
+## Security & Fairness
+
+- Do not trust client messages. Validate inputs and enforce movement speed caps.
+- Prevent cheating by never accepting client‑side position updates.

--- a/.context/rules/domain_net.md
+++ b/.context/rules/domain_net.md
@@ -1,6 +1,6 @@
 # Domain Rules: Networking & Game State
 
-These rules govern the server architecture and client‑server interactions.
+These rules govern the server architecture and client-server interactions.
 
 ## Architecture
 
@@ -10,17 +10,17 @@ These rules govern the server architecture and client‑server interactions.
 ## Server Logic
 
 - Implement the server in Node.js using TypeScript.
-- Maintain an in‑memory game state object for each match. Define `Player` and `GameState` TypeScript classes or interfaces in `/shared` so client and server agree on the shape.
-- Run a fixed‑tick simulation loop at 60 FPS using a self-correcting timer (e.g., with `setTimeout`) instead of `setInterval()` to ensure accuracy. Each tick should:
+- Maintain an in-memory game state object for each match. Define `Player` and `GameState` TypeScript classes or interfaces in `/shared` so client and server agree on the shape.
+- Run a fixed-tick simulation loop at 60 FPS using a self-correcting timer (e.g., with `setTimeout`) instead of `setInterval()` to ensure accuracy. Each tick should:
   1. Apply velocity to paddles and the ball based on current inputs.
   2. Detect and handle collisions.
-  3. Update scores and power‑up timers.
+  3. Update scores and power-up timers.
   4. Broadcast the minimal state delta to clients via Socket.io `emit`.
 - Clients must send **intent messages** (`{input: 'UP' | 'DOWN' | 'STOP'}`) rather than positions. Do not send full coordinates.
 
 ## Client Logic
 
-- On input, immediately move the local paddle for responsiveness (client‑side prediction) and send the intent to the server.
+- On input, immediately move the local paddle for responsiveness (client-side prediction) and send the intent to the server.
 - When receiving state updates, reconcile the predicted position with the authoritative value. If the difference exceeds 5 pixels, snap to the server position; otherwise continue.
 - For remote entities (opponent paddle and ball), buffer updates and interpolate between the last two states using `Phaser.Math.Linear` to smooth motion.
 
@@ -32,4 +32,4 @@ These rules govern the server architecture and client‑server interactions.
 ## Security & Fairness
 
 - Do not trust client messages. Validate inputs and enforce movement speed caps.
-- Prevent cheating by never accepting client‑side position updates.
+- Prevent cheating by never accepting client-side position updates.

--- a/.context/rules/domain_net.md
+++ b/.context/rules/domain_net.md
@@ -11,7 +11,7 @@ These rules govern the server architecture and client‑server interactions.
 
 - Implement the server in Node.js using TypeScript.
 - Maintain an in‑memory game state object for each match. Define `Player` and `GameState` TypeScript classes or interfaces in `/shared` so client and server agree on the shape.
-- Run a fixed‑tick simulation loop at 60 FPS using `setInterval()` or a game loop library. Each tick should:
+- Run a fixed‑tick simulation loop at 60 FPS using a self-correcting timer (e.g., with `setTimeout`) instead of `setInterval()` to ensure accuracy. Each tick should:
   1. Apply velocity to paddles and the ball based on current inputs.
   2. Detect and handle collisions.
   3. Update scores and power‑up timers.

--- a/.context/rules/domain_qa.md
+++ b/.context/rules/domain_qa.md
@@ -1,0 +1,46 @@
+# Domain Rules: Quality Assurance & Testing
+
+Reliable, self‑healing code is essential when an AI agent is in charge of development. These rules prescribe a layered testing strategy and continuous integration (CI) setup to ensure the game functions correctly across phases.
+
+## Testing Layers
+
+Follow the testing pyramid: many unit tests at the base, a moderate number of integration tests in the middle, and a few end‑to‑end tests at the top【684764494693227†L110-L204】. Each type of test serves a distinct purpose:
+
+### Unit Tests
+
+- Test individual functions, classes, or modules in isolation. For example, verify that the scoring logic increments the correct player’s score or that the paddle’s velocity caps are respected【684764494693227†L148-L156】.
+- Use Jest as the test runner. Configure it with `ts-jest` or `babel-jest` for TypeScript support. Use `expect` assertions to check return values.
+- Mock external dependencies (e.g. Socket.io clients or Firebase calls) using Jest’s mocking utilities so unit tests run fast and deterministically.
+
+### Integration Tests
+
+- Test interactions between modules, such as the server’s networking layer communicating with the game logic or the client retrieving data from the leaderboard API【684764494693227†L158-L169】.
+- Use Jest with Node’s `http` or Socket.io test clients to spin up a server and connect a simulated client. Assert that messages are transmitted correctly and state updates occur as expected.
+- When testing database interactions, use Firebase’s emulators or a mock Firestore instance to avoid hitting production.
+
+### End‑to‑End (E2E) Tests
+
+- Simulate real user flows: launching the game, joining a match, playing a round, submitting a score, and viewing the leaderboard【684764494693227†L177-L194】.
+- Use Playwright or Cypress for browser automation. These frameworks can control multiple browser contexts to simulate two players. Keep E2E tests few and focused on high‑value scenarios to balance coverage with execution time.
+
+## Headless Phaser Testing
+
+- Phaser normally requires a DOM and a Canvas element. In CI, run Phaser in headless mode by using the `Phaser.HEADLESS` renderer and providing a canvas via the `canvas` package or `node‑canvas`. Use jsdom to mock the DOM environment【795071169652698†L469-L487】.
+- Write tests that instantiate scenes, update them for a number of frames, and assert state changes. For example, spawn a ball with a known velocity, call `scene.update()` 60 times (1 second), and assert that its position has advanced accordingly【795071169652698†L481-L487】.
+
+## Self‑Healing CI Pipeline
+
+- Configure a GitHub Actions workflow (`.github/workflows/ci-tests.yml`) to run on every push. The pipeline should install dependencies, lint the code, run the full test suite, and build the client/server【795071169652698†L491-L503】.
+- If tests fail, capture the error logs. According to the agent workflow, the AI must read the logs, fix the underlying issue, and only then mark the task as complete in `.context/state/active_task.md`【795071169652698†L491-L503】. This closed feedback loop helps maintain code quality.
+
+## Test‑Driven Development (TDD)
+
+- For critical systems such as the physics engine and networking protocol, consider writing tests before implementing the code. This helps clarify requirements and ensures the agent builds only what is necessary.
+- Even if not strictly practising TDD, always accompany new features with appropriate tests at the relevant layer.
+
+## Coverage & Reporting
+
+- Configure Jest to generate code coverage reports. Aim for >80 % coverage across the core game logic. Low coverage hotspots are candidates for additional tests.
+- Integrate coverage reporting into the CI pipeline so regressions are visible.
+
+By adhering to these QA rules, the AI agent can detect regressions early, gain confidence in its code, and self‑correct when tests fail. This layered strategy aligns with industry best practices and the guidance from the project organization document【684764494693227†L110-L204】.

--- a/.context/rules/domain_qa.md
+++ b/.context/rules/domain_qa.md
@@ -4,7 +4,7 @@ Reliable, self‑healing code is essential when an AI agent is in charge of deve
 
 ## Testing Layers
 
-Follow the testing pyramid: many unit tests at the base, a moderate number of integration tests in the middle, and a few end‑to‑end tests at the top【684764494693227†L110-L204】. Each type of test serves a distinct purpose:
+Follow the testing pyramid: many unit tests at the base, a moderate number of integration tests in the middle, and a few end‑to‑end tests at the top. Each type of test serves a distinct purpose:
 
 ### Unit Tests
 

--- a/.context/rules/domain_qa.md
+++ b/.context/rules/domain_qa.md
@@ -1,39 +1,39 @@
 # Domain Rules: Quality Assurance & Testing
 
-Reliable, self‑healing code is essential when an AI agent is in charge of development. These rules prescribe a layered testing strategy and continuous integration (CI) setup to ensure the game functions correctly across phases.
+Reliable, self-healing code is essential when an AI agent is in charge of development. These rules prescribe a layered testing strategy and continuous integration (CI) setup to ensure the game functions correctly across phases.
 
 ## Testing Layers
 
-Follow the testing pyramid: many unit tests at the base, a moderate number of integration tests in the middle, and a few end‑to‑end tests at the top. Each type of test serves a distinct purpose:
+Follow the testing pyramid: many unit tests at the base, a moderate number of integration tests in the middle, and a few end-to-end tests at the top. Each type of test serves a distinct purpose:
 
 ### Unit Tests
 
-- Test individual functions, classes, or modules in isolation. For example, verify that the scoring logic increments the correct player’s score or that the paddle’s velocity caps are respected【684764494693227†L148-L156】.
+- Test individual functions, classes, or modules in isolation. For example, verify that the scoring logic increments the correct player’s score or that the paddle’s velocity caps are respected.
 - Use Jest as the test runner. Configure it with `ts-jest` or `babel-jest` for TypeScript support. Use `expect` assertions to check return values.
 - Mock external dependencies (e.g. Socket.io clients or Firebase calls) using Jest’s mocking utilities so unit tests run fast and deterministically.
 
 ### Integration Tests
 
-- Test interactions between modules, such as the server’s networking layer communicating with the game logic or the client retrieving data from the leaderboard API【684764494693227†L158-L169】.
+- Test interactions between modules, such as the server’s networking layer communicating with the game logic or the client retrieving data from the leaderboard API.
 - Use Jest with Node’s `http` or Socket.io test clients to spin up a server and connect a simulated client. Assert that messages are transmitted correctly and state updates occur as expected.
 - When testing database interactions, use Firebase’s emulators or a mock Firestore instance to avoid hitting production.
 
-### End‑to‑End (E2E) Tests
+### End-to-End (E2E) Tests
 
-- Simulate real user flows: launching the game, joining a match, playing a round, submitting a score, and viewing the leaderboard【684764494693227†L177-L194】.
-- Use Playwright or Cypress for browser automation. These frameworks can control multiple browser contexts to simulate two players. Keep E2E tests few and focused on high‑value scenarios to balance coverage with execution time.
+- Simulate real user flows: launching the game, joining a match, playing a round, submitting a score, and viewing the leaderboard.
+- Use Playwright or Cypress for browser automation. These frameworks can control multiple browser contexts to simulate two players. Keep E2E tests few and focused on high-value scenarios to balance coverage with execution time.
 
 ## Headless Phaser Testing
 
-- Phaser normally requires a DOM and a Canvas element. In CI, run Phaser in headless mode by using the `Phaser.HEADLESS` renderer and providing a canvas via the `canvas` package or `node‑canvas`. Use jsdom to mock the DOM environment【795071169652698†L469-L487】.
-- Write tests that instantiate scenes, update them for a number of frames, and assert state changes. For example, spawn a ball with a known velocity, call `scene.update()` 60 times (1 second), and assert that its position has advanced accordingly【795071169652698†L481-L487】.
+- Phaser normally requires a DOM and a Canvas element. In CI, run Phaser in headless mode by using the `Phaser.HEADLESS` renderer and providing a canvas via the `canvas` package or `node-canvas`. Use jsdom to mock the DOM environment.
+- Write tests that instantiate scenes, update them for a number of frames, and assert state changes. For example, spawn a ball with a known velocity, call `scene.update()` 60 times (1 second), and assert that its position has advanced accordingly.
 
-## Self‑Healing CI Pipeline
+## Self-Healing CI Pipeline
 
-- Configure a GitHub Actions workflow (`.github/workflows/ci-tests.yml`) to run on every push. The pipeline should install dependencies, lint the code, run the full test suite, and build the client/server【795071169652698†L491-L503】.
-- If tests fail, capture the error logs. According to the agent workflow, the AI must read the logs, fix the underlying issue, and only then mark the task as complete in `.context/state/active_task.md`【795071169652698†L491-L503】. This closed feedback loop helps maintain code quality.
+- Configure a GitHub Actions workflow (`.github/workflows/ci-tests.yml`) to run on every push. The pipeline should install dependencies, lint the code, run the full test suite, and build the client/server.
+- If tests fail, capture the error logs. According to the agent workflow, the AI must read the logs, fix the underlying issue, and only then mark the task as complete in `.context/state/active_task.md`. This closed feedback loop helps maintain code quality.
 
-## Test‑Driven Development (TDD)
+## Test-Driven Development (TDD)
 
 - For critical systems such as the physics engine and networking protocol, consider writing tests before implementing the code. This helps clarify requirements and ensures the agent builds only what is necessary.
 - Even if not strictly practising TDD, always accompany new features with appropriate tests at the relevant layer.
@@ -43,4 +43,4 @@ Follow the testing pyramid: many unit tests at the base, a moderate number of in
 - Configure Jest to generate code coverage reports. Aim for >80 % coverage across the core game logic. Low coverage hotspots are candidates for additional tests.
 - Integrate coverage reporting into the CI pipeline so regressions are visible.
 
-By adhering to these QA rules, the AI agent can detect regressions early, gain confidence in its code, and self‑correct when tests fail. This layered strategy aligns with industry best practices and the guidance from the project organization document【684764494693227†L110-L204】.
+By adhering to these QA rules, the AI agent can detect regressions early, gain confidence in its code, and self-correct when tests fail. This layered strategy aligns with industry best practices and the guidance from the project organization document.

--- a/.context/rules/domain_ui.md
+++ b/.context/rules/domain_ui.md
@@ -1,10 +1,10 @@
 # Domain Rules: UI & Graphics
 
-These rules govern all client‑side rendering and input.
+These rules govern all client-side rendering and input.
 
 ## Aesthetic Guidelines
 
-- **Style:** retro‑futuristic synthwave.
+- **Style:** retro-futuristic synthwave.
 - **Colors:**
   - Background: `#090D40` (deep void blue).
   - Grid lines: `#2b2b2b` (dark grey perspective lines).
@@ -16,17 +16,17 @@ These rules govern all client‑side rendering and input.
 ## Mobile Responsiveness
 
 - Use `Phaser.Scale.FIT` for the scale mode and `autoCenter: Phaser.Scale.CENTER_BOTH`.
-- Never use hard‑coded pixel coordinates for positioning. Always use relative positioning based on `this.cameras.main.width` and `height`, e.g. `this.cameras.main.width * 0.5` to centre objects.
+- Never use hard-coded pixel coordinates for positioning. Always use relative positioning based on `this.cameras.main.width` and `height`, e.g. `this.cameras.main.width * 0.5` to centre objects.
 - Use flex spacing for UI overlays (pause menu, scoreboard) to maintain layout across aspect ratios.
 
 ## Input Scheme
 
 - Detect whether the device is mobile via `this.sys.game.device.os.desktop`.
-- **Mobile:** Divide the canvas into two horizontal invisible zones: touching the top half moves the paddle up; touching the bottom half moves it down. Use `this.input.addPointer(2)` to enable multi‑touch and prevent locking.
+- **Mobile:** Divide the canvas into two horizontal invisible zones: touching the top half moves the paddle up; touching the bottom half moves it down. Use `this.input.addPointer(2)` to enable multi-touch and prevent locking.
 - **Desktop:** Map the arrow keys (`UP`, `DOWN`) for paddle movement and allow `P` to pause.
 
 ## Effects
 
 - Apply a CRT scanline shader when WebGL is available, and fall back to plain Canvas on devices without WebGL.
 - Use PostFX pipelines for bloom/glow on paddles and ball.
-- Add juice such as screen shake on scoring and particle explosions for power‑ups in later phases.
+- Add juice such as screen shake on scoring and particle explosions for power-ups in later phases.

--- a/.context/rules/domain_ui.md
+++ b/.context/rules/domain_ui.md
@@ -22,7 +22,7 @@ These rules govern all client‑side rendering and input.
 ## Input Scheme
 
 - Detect whether the device is mobile via `this.sys.game.device.os.desktop`.
-- **Mobile:** Divide the canvas into two invisible zones. Touching the left half moves the paddle up; touching the right half moves it down. Use `this.input.addPointer(2)` to enable multi‑touch and prevent locking.
+- **Mobile:** Divide the canvas into two horizontal invisible zones: touching the top half moves the paddle up; touching the bottom half moves it down. Use `this.input.addPointer(2)` to enable multi‑touch and prevent locking.
 - **Desktop:** Map the arrow keys (`UP`, `DOWN`) for paddle movement and allow `P` to pause.
 
 ## Effects

--- a/.context/rules/domain_ui.md
+++ b/.context/rules/domain_ui.md
@@ -1,0 +1,32 @@
+# Domain Rules: UI & Graphics
+
+These rules govern all client‑side rendering and input.
+
+## Aesthetic Guidelines
+
+- **Style:** retro‑futuristic synthwave.
+- **Colors:**
+  - Background: `#090D40` (deep void blue).
+  - Grid lines: `#2b2b2b` (dark grey perspective lines).
+  - Player 1 paddle: `#FF005C` (neon pink) with a bloom PostFX (strength 2.0).
+  - Player 2 paddle: `#00C4FF` (cyber cyan) with a bloom PostFX (strength 2.0).
+  - Ball: `#FFFFFF` (white) with a particle trail coloured according to the last paddle that touched it.
+- **Typography:** Use the Google Font **“Press Start 2P”** for all HUD elements. Load it via the WebFontLoader plugin.
+
+## Mobile Responsiveness
+
+- Use `Phaser.Scale.FIT` for the scale mode and `autoCenter: Phaser.Scale.CENTER_BOTH`.
+- Never use hard‑coded pixel coordinates for positioning. Always use relative positioning based on `this.cameras.main.width` and `height`, e.g. `this.cameras.main.width * 0.5` to centre objects.
+- Use flex spacing for UI overlays (pause menu, scoreboard) to maintain layout across aspect ratios.
+
+## Input Scheme
+
+- Detect whether the device is mobile via `this.sys.game.device.os.desktop`.
+- **Mobile:** Divide the canvas into two invisible zones. Touching the left half moves the paddle up; touching the right half moves it down. Use `this.input.addPointer(2)` to enable multi‑touch and prevent locking.
+- **Desktop:** Map the arrow keys (`UP`, `DOWN`) for paddle movement and allow `P` to pause.
+
+## Effects
+
+- Apply a CRT scanline shader when WebGL is available, and fall back to plain Canvas on devices without WebGL.
+- Use PostFX pipelines for bloom/glow on paddles and ball.
+- Add juice such as screen shake on scoring and particle explosions for power‑ups in later phases.

--- a/.context/rules/master.md
+++ b/.context/rules/master.md
@@ -4,7 +4,7 @@ You are an expert game developer specialising in HTML5, Phaser 3, Node.js and S
 
 1. **Initialize** – Read `.context/state/active_task.md` to determine the current phase and immediate goal before doing any work.
 2. **Load Constraints** – Identify which domain is relevant to the active task (`ui`, `net`, `audio`, `leaderboard`, `qa`) and read the corresponding file from `.context/rules/` (e.g. `domain_ui.md`, `domain_net.md`, etc.).
-3. **Plan** – Before editing code, summarise your understanding of the task and propose a step‑by‑step plan. Mention which files you intend to create or modify and how you will test your changes.
+3. **Plan** – Before editing code, summarise your understanding of the task and propose a step-by-step plan. Mention which files you intend to create or modify and how you will test your changes.
 4. **Implement** – Write code in small, testable commits. Adhere to the conventions described in the domain rule files and the repository guide.
 5. **Persist** – After completing a task or making progress, update `.context/state/active_task.md` with what you did, what remains, and what the next step should be.
 

--- a/.context/rules/master.md
+++ b/.context/rules/master.md
@@ -1,0 +1,11 @@
+# Master Rule – Retro Pong Agent
+
+You are an expert game developer specialising in HTML5, Phaser 3, Node.js and Socket.io. Your memory is stateless beyond the contents of the `.context` folder. Follow this protocol strictly:
+
+1. **Initialize** – Read `.context/state/active_task.md` to determine the current phase and immediate goal before doing any work.
+2. **Load Constraints** – Identify which domain is relevant to the active task (`ui`, `net`, `audio`, `leaderboard`, `qa`) and read the corresponding file from `.context/rules/` (e.g. `domain_ui.md`, `domain_net.md`, etc.).
+3. **Plan** – Before editing code, summarise your understanding of the task and propose a step‑by‑step plan. Mention which files you intend to create or modify and how you will test your changes.
+4. **Implement** – Write code in small, testable commits. Adhere to the conventions described in the domain rule files and the repository guide.
+5. **Persist** – After completing a task or making progress, update `.context/state/active_task.md` with what you did, what remains, and what the next step should be.
+
+Never assume or guess about the code; always read the existing files first. If a rule file forbids a technology or pattern (e.g. using pixel coordinates for UI), do not use it. When in doubt, ask clarifying questions according to the guidelines.

--- a/.context/state/active_task.md
+++ b/.context/state/active_task.md
@@ -11,8 +11,8 @@ You are beginning Phase 1 of the development roadmap. Your goal is to produce a
 1. **Set up the project:** Initialize a TypeScript project using Vite or Webpack. Install Phaser 3 via npm or include it via a CDN in your HTML. Commit the initial scaffold (`package.json`, bundler config, `index.html`).
 2. **Implement basic scenes:** Create a `BootScene` that loads the `Press Start 2P` font, shaders, and any stub assets; and a `GameScene` that will contain the core game.
 3. **Create game objects:** Implement `Paddle` and `Ball` classes using Phaser’s Arcade Physics. Respect the visual rules from `domain_ui.md` (synthwave colours, bloom effects, CRT scanlines).
-4. **Handle input:** Implement split‑screen touch controls for mobile and arrow keys for desktop as described in `domain_ui.md`.
+4. **Handle input:** Implement split-screen touch controls for mobile and arrow keys for desktop as described in `domain_ui.md`.
 5. **Add scoring and UI:** Draw score text using relative positioning. Make sure the ball resets after a point.
 6. **Validate:** Run the game locally in a browser. The ball should bounce off walls and paddles, paddles should respond to input, and the game should scale across aspect ratios.
 
-**Next Step:** After completing the above tasks and committing the working single‑player game, update this file with a summary of what you did, any remaining TODOs, and mark yourself ready to start Phase 2 (Networking Plumbing).
+**Next Step:** After completing the above tasks and committing the working single-player game, update this file with a summary of what you did, any remaining TODOs, and mark yourself ready to start Phase 2 (Networking Plumbing).

--- a/.context/state/active_task.md
+++ b/.context/state/active_task.md
@@ -1,0 +1,18 @@
+# Active Task
+
+**Phase:** 1 – Core Loop
+
+**Status:** Not Started
+
+**Task Description:**
+
+You are beginning Phase 1 of the development roadmap. Your goal is to produce a working, local Pong game without networking. Follow these steps:
+
+1. **Set up the project:** Initialize a TypeScript project using Vite or Webpack. Install Phaser 3 via npm or include it via a CDN in your HTML. Commit the initial scaffold (`package.json`, bundler config, `index.html`).
+2. **Implement basic scenes:** Create a `BootScene` that loads the `Press Start 2P` font, shaders, and any stub assets; and a `GameScene` that will contain the core game.
+3. **Create game objects:** Implement `Paddle` and `Ball` classes using Phaser’s Arcade Physics. Respect the visual rules from `domain_ui.md` (synthwave colours, bloom effects, CRT scanlines).
+4. **Handle input:** Implement split‑screen touch controls for mobile and arrow keys for desktop as described in `domain_ui.md`.
+5. **Add scoring and UI:** Draw score text using relative positioning. Make sure the ball resets after a point.
+6. **Validate:** Run the game locally in a browser. The ball should bounce off walls and paddles, paddles should respond to input, and the game should scale across aspect ratios.
+
+**Next Step:** After completing the above tasks and committing the working single‑player game, update this file with a summary of what you did, any remaining TODOs, and mark yourself ready to start Phase 2 (Networking Plumbing).

--- a/AI_REPO_GUIDE.md
+++ b/AI_REPO_GUIDE.md
@@ -1,7 +1,7 @@
 # Retro Pong Game – AI Repository Guide
 
 ## What This Repo Does
-This project implements a retro‑style Pong game optimized for mobile browsers. It features real‑time multiplayer, touch‑friendly controls, a power‑up system, retro synthwave visuals and sound, and a persistent leaderboard. The client runs entirely in the browser using Phaser 3, while the server uses Node.js with Socket.io to synchronize game state. A Firebase Realtime Database stores leaderboards.
+This project implements a retro‑style Pong game optimized for mobile browsers. It features real‑time multiplayer, touch‑friendly controls, a power‑up system, retro synthwave visuals and sound, and a persistent leaderboard. The client runs entirely in the browser using Phaser 3, while the server uses Node.js with Socket.io to synchronize game state. A Firebase Firestore database stores leaderboards.
 
 ## Tech Stack
 

--- a/AI_REPO_GUIDE.md
+++ b/AI_REPO_GUIDE.md
@@ -1,7 +1,7 @@
 # Retro Pong Game – AI Repository Guide
 
 ## What This Repo Does
-This project implements a retro‑style Pong game optimized for mobile browsers. It features real‑time multiplayer, touch‑friendly controls, a power‑up system, retro synthwave visuals and sound, and a persistent leaderboard. The client runs entirely in the browser using Phaser 3, while the server uses Node.js with Socket.io to synchronize game state. A Firebase Firestore database stores leaderboards.
+This project implements a retro-style Pong game optimized for mobile browsers. It features real-time multiplayer, touch-friendly controls, a power-up system, retro synthwave visuals and sound, and a persistent leaderboard. The client runs entirely in the browser using Phaser 3, while the server uses Node.js with Socket.io to synchronize game state. A Firebase Firestore database stores leaderboards.
 
 ## Tech Stack
 
@@ -10,16 +10,16 @@ This project implements a retro‑style Pong game optimized for mobile browsers.
 - **Server Framework:** Node.js with Socket.io for WebSocket communication
 - **Persistence:** Firebase v9 Firestore (NoSQL document database) for leaderboards. Use the modular SDK (e.g. `getFirestore`, `collection`, `addDoc`, `getDocs`, `orderBy`, `limit`) to record and query high scores.
 - **Build Tools:** Vite/Webpack for client bundling; npm scripts for server
-- **Test Framework:** Jest with jsdom and node‑canvas for headless Phaser tests
-- **Deployment:** Deploy via a Platform‑as‑a‑Service (e.g. Render, Railway). The Node server hosts API and WebSocket endpoints and can optionally serve static client assets.
+- **Test Framework:** Jest with jsdom and node-canvas for headless Phaser tests
+- **Deployment:** Deploy via a Platform-as-a-Service (e.g. Render, Railway). The Node server hosts API and WebSocket endpoints and can optionally serve static client assets.
 
 ## Folder Map
 
-- `/client` — Browser‑based game client built with Phaser 3 (scenes, sprites, input, UI).
+- `/client` — Browser-based game client built with Phaser 3 (scenes, sprites, input, UI).
 - `/server` — Node.js server handling authoritative game logic, networking via Socket.io, and leaderboard endpoints.
 - `/shared` — Shared TypeScript types/constants used by both client and server (e.g. enum for input commands).
 - `/assets` — Game assets such as sprites, fonts, audio sprites, and shaders.
-- `/tests` — Unit, integration, and end‑to‑end tests. Mirrors the source layout.
+- `/tests` — Unit, integration, and end-to-end tests. Mirrors the source layout.
 - `/.context` — Agent memory. Contains immutable rules (`.context/rules`), the development roadmap (`.context/roadmap.md`) and the current task state (`.context/state/active_task.md`).
 - `/.github` — CI configurations and prompts used by GitHub Copilot or other AI tools.
 
@@ -49,13 +49,13 @@ This project implements a retro‑style Pong game optimized for mobile browsers.
 
 ## How to Test
 
-- **Unit tests:** `npm test`. Tests are written using Jest; headless Phaser tests use jsdom and node‑canvas.
+- **Unit tests:** `npm test`. Tests are written using Jest; headless Phaser tests use jsdom and node-canvas.
 - **Integration tests:** Use `npm run test:integration` to spin up a server and client to verify networking.
-- **End‑to‑End tests:** Use `npm run test:e2e` with Playwright or a similar framework to simulate full gameplay flows.
+- **End-to-End tests:** Use `npm run test:e2e` with Playwright or a similar framework to simulate full gameplay flows.
 
 ## Conventions
 
-- **Responsive Layout:** Always use `Phaser.Scale.FIT` and relative positioning (`width * 0.5`) for UI elements. Avoid hard‑coded pixel coordinates.
+- **Responsive Layout:** Always use `Phaser.Scale.FIT` and relative positioning (`width * 0.5`) for UI elements. Avoid hard-coded pixel coordinates.
 - **Input Handling:** On mobile, split the screen into left/right invisible zones for paddle movement; on desktop, map arrow keys.
 - **Color & Typography:** Use the synthwave palette and `Press Start 2P` font described in `.context/rules/domain_ui.md`.
 - **Networking:** The server is authoritative. Clients send input commands (`UP`, `DOWN`, `STOP`); the server runs physics at 60 Hz, updates positions, and broadcasts state.
@@ -68,14 +68,14 @@ This project implements a retro‑style Pong game optimized for mobile browsers.
 - **New scenes:** `client/src/scenes`.
 - **New server rooms or handlers:** `server/src/rooms`.
 - **Shared constants/enums:** `shared/types.ts`.
-- **Power‑up logic:** Encapsulate in `client/src/powerups` and mirror server logic in `server/src/powerups`.
+- **Power-up logic:** Encapsulate in `client/src/powerups` and mirror server logic in `server/src/powerups`.
 - **Leaderboard functions:** `server/src/leaderboard.ts` and call them from the server when matches end.
 
 ## Troubleshooting & Gotchas
 
 - If the game doesn’t scale correctly, ensure `scale: { mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH }`.
 - Mobile audio may be silent until the first tap; call a silent sound in response to user input to unlock.
-- When running tests in CI, use headless mode (`type: Phaser.HEADLESS`) and provide a canvas via node‑canvas.
+- When running tests in CI, use headless mode (`type: Phaser.HEADLESS`) and provide a canvas via node-canvas.
 - Ensure Firebase credentials are stored securely (e.g. via environment variables) and are **not** committed to the repo.
 
 Use this guide as the canonical reference for the repository. Update it whenever commands, structure, or conventions change.

--- a/AI_REPO_GUIDE.md
+++ b/AI_REPO_GUIDE.md
@@ -1,0 +1,81 @@
+# Retro Pong Game – AI Repository Guide
+
+## What This Repo Does
+This project implements a retro‑style Pong game optimized for mobile browsers. It features real‑time multiplayer, touch‑friendly controls, a power‑up system, retro synthwave visuals and sound, and a persistent leaderboard. The client runs entirely in the browser using Phaser 3, while the server uses Node.js with Socket.io to synchronize game state. A Firebase Realtime Database stores leaderboards.
+
+## Tech Stack
+
+- **Language:** TypeScript (client & server)
+- **Client Framework:** Phaser 3 with Vite or Webpack bundler
+- **Server Framework:** Node.js with Socket.io for WebSocket communication
+- **Persistence:** Firebase v9 Firestore (NoSQL document database) for leaderboards. Use the modular SDK (e.g. `getFirestore`, `collection`, `addDoc`, `getDocs`, `orderBy`, `limit`) to record and query high scores.
+- **Build Tools:** Vite/Webpack for client bundling; npm scripts for server
+- **Test Framework:** Jest with jsdom and node‑canvas for headless Phaser tests
+- **Deployment:** Deploy via a Platform‑as‑a‑Service (e.g. Render, Railway). The Node server hosts API and WebSocket endpoints and can optionally serve static client assets.
+
+## Folder Map
+
+- `/client` — Browser‑based game client built with Phaser 3 (scenes, sprites, input, UI).
+- `/server` — Node.js server handling authoritative game logic, networking via Socket.io, and leaderboard endpoints.
+- `/shared` — Shared TypeScript types/constants used by both client and server (e.g. enum for input commands).
+- `/assets` — Game assets such as sprites, fonts, audio sprites, and shaders.
+- `/tests` — Unit, integration, and end‑to‑end tests. Mirrors the source layout.
+- `/.context` — Agent memory. Contains immutable rules (`.context/rules`), the development roadmap (`.context/roadmap.md`) and the current task state (`.context/state/active_task.md`).
+- `/.github` — CI configurations and prompts used by GitHub Copilot or other AI tools.
+
+## Key Entry Points
+
+- **Client:** `client/src/main.ts` bootstraps the Phaser game and loads the initial scene. Scenes are located in `client/src/scenes`.
+- **Server:** `server/src/index.ts` creates the HTTP server and Socket.io instance, registers rooms, and starts the authoritative game loop.
+- **Shared Types:** `shared/types.ts` defines interfaces for messages and game state.
+
+## Quickstart
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the client in development mode with live reload:
+   ```bash
+   cd client
+   npm run dev
+   ```
+3. Run the server:
+   ```bash
+   cd server
+   npm start
+   ```
+4. Open `http://localhost:5173` in two browser windows to test local multiplayer.
+
+## How to Test
+
+- **Unit tests:** `npm test`. Tests are written using Jest; headless Phaser tests use jsdom and node‑canvas.
+- **Integration tests:** Use `npm run test:integration` to spin up a server and client to verify networking.
+- **End‑to‑End tests:** Use `npm run test:e2e` with Playwright or a similar framework to simulate full gameplay flows.
+
+## Conventions
+
+- **Responsive Layout:** Always use `Phaser.Scale.FIT` and relative positioning (`width * 0.5`) for UI elements. Avoid hard‑coded pixel coordinates.
+- **Input Handling:** On mobile, split the screen into left/right invisible zones for paddle movement; on desktop, map arrow keys.
+- **Color & Typography:** Use the synthwave palette and `Press Start 2P` font described in `.context/rules/domain_ui.md`.
+- **Networking:** The server is authoritative. Clients send input commands (`UP`, `DOWN`, `STOP`); the server runs physics at 60 Hz, updates positions, and broadcasts state.
+- **Leaderboards:** Use Firestore functions from the modular SDK to record scores after each match and retrieve the top 10 scores ordered by `score` descending. See `.context/rules/domain_leaderboard.md` for implementation guidance.
+- **Audio:** Use an audio sprite (single sound file with cue map) and unlock audio on first user interaction.
+- **Testing:** Each new feature must include unit tests. Networking and physics changes require integration tests. Keep CI green before merging.
+
+## Where to Add Things
+
+- **New scenes:** `client/src/scenes`.
+- **New server rooms or handlers:** `server/src/rooms`.
+- **Shared constants/enums:** `shared/types.ts`.
+- **Power‑up logic:** Encapsulate in `client/src/powerups` and mirror server logic in `server/src/powerups`.
+- **Leaderboard functions:** `server/src/leaderboard.ts` and call them from the server when matches end.
+
+## Troubleshooting & Gotchas
+
+- If the game doesn’t scale correctly, ensure `scale: { mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH }`.
+- Mobile audio may be silent until the first tap; call a silent sound in response to user input to unlock.
+- When running tests in CI, use headless mode (`type: Phaser.HEADLESS`) and provide a canvas via node‑canvas.
+- Ensure Firebase credentials are stored securely (e.g. via environment variables) and are **not** committed to the repo.
+
+Use this guide as the canonical reference for the repository. Update it whenever commands, structure, or conventions change.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets up project planning and execution scaffolding for an AI-driven Pong game. No runtime code changes.
> 
> - Adds `/.context/roadmap.md` outlining phased milestones (core loop → networking → authoritative server → polish/deployment)
> - Introduces domain rule files: `domain_ui.md`, `domain_net.md`, `domain_audio.md`, `domain_leaderboard.md`, `domain_qa.md`
> - Adds `/.context/rules/master.md` defining the agent workflow (initialize, load constraints, plan, implement, persist)
> - Initializes `/.context/state/active_task.md` with Phase 1 objectives and next steps
> - Adds `AI_REPO_GUIDE.md` documenting repo structure, tech stack, conventions, testing, and quickstart
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e64a3ac8e111f7ba36337989098b703daaffddf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->